### PR TITLE
Setup typescript hotreload for local emulator usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 4. `npm install -g firebase-tools`
 5. `npm install`
 6. run `firebase login --no-localhost` then login with your betterSG email
-7. run `npm run serve`
-8. you should now be able to hit the url at http://127.0.0.1:5001/checkmate-373101/asia-southeast1/xxxxx successfully
-9.  Now can work on your individual functions in the /functions/definitions folder
-10. Uncomment the exports when ready to test with the local emulator!
-11. Rmb to use https://ngrok.com/ (can install vs code extension) to expose localhost as an internet URL, in case you want to run locally but test with actual Whatsapp and Telegram. Note...might need to have premium Ngrok for this to work with whatsapp.
+7. run `npm run build:watch` for typescript to build and work with emulator's hot reload
+8. run `npm run serve`
+9. you should now be able to hit the url at http://127.0.0.1:5001/checkmate-373101/asia-southeast1/xxxxx successfully
+10.  Now can work on your individual functions in the /functions/definitions folder
+11. Uncomment the exports when ready to test with the local emulator!
+12. Rmb to use https://ngrok.com/ (can install vs code extension) to expose localhost as an internet URL, in case you want to run locally but test with actual Whatsapp and Telegram. Note...might need to have premium Ngrok for this to work with whatsapp.
 
 ## Things to note
 1. Put all keys and access tokens in the .env file and make sure its gitignored!

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 4. `npm install -g firebase-tools`
 5. `npm install`
 6. run `firebase login --no-localhost` then login with your betterSG email
-7. run `npm run build:watch` for typescript to build and work with emulator's hot reload
-8. run `npm run serve`
+7. run `npm run build:watch` on one shell for typescript to build and work with emulator's hot reload
+8. run `npm run serve` on another shell
 9. you should now be able to hit the url at http://127.0.0.1:5001/checkmate-373101/asia-southeast1/xxxxx successfully
 10.  Now can work on your individual functions in the /functions/definitions folder
 11. Uncomment the exports when ready to test with the local emulator!

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,13 +3,14 @@
   "description": "Cloud Functions for Firebase",
   "scripts": {
     "lint": "",
-    "serve": "npm run build && firebase emulators:start",
-    "shell": "npm run build && firebase functions:shell",
+    "serve": "firebase emulators:start",
+    "shell": "firebase functions:shell",
     "start": "npm run shell",
     "predeploy": "npm run build",
     "deploy": "firebase deploy --only functions",
-    "logs": "npm run build && firebase functions:log",
-    "build": "tsc"
+    "logs": "firebase functions:log",
+    "build": "tsc",
+    "build:watch": "npm run build -- --watch"
   },
   "engines": {
     "node": "18"

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -13,5 +13,21 @@
   ],
   "exclude": [
     "./lib/**/*"
-  ]
+  ],
+  
+  // NEW: Options for file/directory watching
+  "watchOptions": {
+    // Use native file system events for files and directories
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    // Poll files for updates more frequently
+    // when they're updated a lot.
+    "fallbackPolling": "dynamicPriority",
+    // Don't coalesce watch notification
+    "synchronousWatchDirectory": true,
+    // Finally, two additional settings for reducing the amount of possible
+    // files to track  work from these directories
+    "excludeDirectories": ["**/node_modules", "./lib"],
+    // "excludeFiles": ["build/fileWhichChangesOften.ts"]
+  }
 }


### PR DESCRIPTION
This method works pretty well as tsc caches the previously built files and rebuilds files changed only instead of rebuilding the whole project.

Requires running 2 shell windows, one monitors for tsc errors, while the other is used for the emulator logs.