### PR TITLE
disable reply messages

### DIFF
--- a/functions/src/definitions/common/sendWhatsappMessage.js
+++ b/functions/src/definitions/common/sendWhatsappMessage.js
@@ -256,6 +256,10 @@ async function callWhatsappSendMessageApi(data, bot) {
       phoneNumberId = process.env.WHATSAPP_USER_BOT_PHONE_NUMBER_ID
     }
   }
+  // to force no replies
+  if (data.context) {
+    delete data.context
+  }
   const response = await axios({
     method: "POST", // Required, HTTP method, a string, e.g. POST, GET
     url:


### PR DESCRIPTION
Hotfix for issue where whatsapp messages that reply to earlier messages are throwing API errors

https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages#replies

https://business.facebook.com/direct-support/question/2257768874410757/?force_full_site=0&business_id=1785741798462872